### PR TITLE
Remove e2e from requirements to publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,7 +169,6 @@ workflows:
       - publish:
           requires:
             - test-unit
-            - test-e2e
             - test-lint
             - test-cypress
           filters:


### PR DESCRIPTION
e2e are notoriously flakey, and are just getting in our way when deploying. We've started moving to Cypress which seems to be doing much better. Our e2e should still run, so we can manually check to see if failures are legit, but otherwise, once merged, deployment will happen without their passing.