### PR TITLE
Ensure the event is loaded to trigger the orders

### DIFF
--- a/src/dashboard/events/cd-dashboard-upcoming-event.vue
+++ b/src/dashboard/events/cd-dashboard-upcoming-event.vue
@@ -135,7 +135,9 @@
     },
     watch: {
       event() {
-        this.loadOrders();
+        if (this.event && this.event.id) {
+          this.loadOrders();
+        }
       },
     },
     created() {


### PR DESCRIPTION
We reset events in the parent when loading oldEvents, triggering the watcher, which send invalid API calls