### PR TITLE
Pass down cascade so children are being deleted as well

### DIFF
--- a/src/users/cdf-manage.vue
+++ b/src/users/cdf-manage.vue
@@ -168,7 +168,7 @@
         // eslint-disable-next-line no-alert
         if (window.confirm(`Are you 100% sure you know what you are about to do to this poor ${this.user.name} ?`)) {
           try {
-            await UserService.delete(this.user.id, !!soft);
+            await UserService.delete(this.user.id, { soft: !!soft, cascade: true });
             this.deleted = true;
           } catch (e) {
             this.errors.add('deletionFailed', 'Something went absolutly wrong');

--- a/src/users/service.js
+++ b/src/users/service.js
@@ -27,7 +27,7 @@ const UserService = {
 
   load: (userId, query) => Vue.http.get(`${Vue.config.apiServer}/api/3.0/users/${userId}`, { params: query }),
 
-  delete: (userId, soft) => Vue.http.delete(`${Vue.config.apiServer}/api/3.0/users/${userId}`, { body: { soft } }),
+  delete: (userId, body) => Vue.http.delete(`${Vue.config.apiServer}/api/3.0/users/${userId}`, { body }),
 
   userProfileData: userId => Vue.http.post(`${Vue.config.apiServer}/api/2.0/profiles/user-profile-data`, { query: { userId } }),
 

--- a/test/unit/specs/users/cdf-manage.spec.js
+++ b/test/unit/specs/users/cdf-manage.spec.js
@@ -220,7 +220,7 @@ describe('CDFManageUsers', () => {
       // ACT
       await vm.deleteUser();
       // ASSERT
-      expect(MockUserService.delete).to.have.been.calledWith('u1', false);
+      expect(MockUserService.delete).to.have.been.calledWith('u1', { soft: false, cascade: true });
       expect(vm.deleted).to.be.true;
     });
     it('should softDelete', async () => {
@@ -236,7 +236,7 @@ describe('CDFManageUsers', () => {
       // ACT
       await vm.deleteUser(true);
       // ASSERT
-      expect(MockUserService.delete).to.have.been.calledWith('u1', true);
+      expect(MockUserService.delete).to.have.been.calledWith('u1', { soft: true, cascade: true });
       expect(vm.deleted).to.be.true;
     });
     it('should register an error on retrieval of data', async () => {


### PR DESCRIPTION
Cascade not being defined ensured that only the parent was being deleted, which isn't the expected behavior for this page