### PR TITLE
Make the calendar subscribe link blue

### DIFF
--- a/src/common/variables.less
+++ b/src/common/variables.less
@@ -7,6 +7,7 @@
 @side-column-grey: #f4f5f6;
 @divider-grey: #CAC4CE;
 @link-color: #0093D5;
+@link-hover-color: #005e89;
 
 /* Font sizes */
 @font-size-medium: ceil((@font-size-base * 1.1));

--- a/src/events/cd-ics-link.vue
+++ b/src/events/cd-ics-link.vue
@@ -62,6 +62,13 @@
   @import "../common/variables";
 
   .cd-ics-link {
+    summary {
+      cursor: pointer;
+      color: @link-color;
+      &:hover {
+        color: #005e89;
+      }
+    }
     input {
       max-width: 170px;
       border-right-width: 0px;
@@ -79,13 +86,6 @@
       position: relative;
       &--hidden {
         opacity: 1;
-      }
-    }
-    summary {
-      cursor: pointer;
-      color: @link-color;
-      &:hover {
-        color: #005e89;
       }
     }
   }

--- a/src/events/cd-ics-link.vue
+++ b/src/events/cd-ics-link.vue
@@ -85,7 +85,7 @@
       cursor: pointer;
       color: @link-color;
       &:hover {
-        color: #005e89;
+        color: @link-hover-color;
       }
     }
   }

--- a/src/events/cd-ics-link.vue
+++ b/src/events/cd-ics-link.vue
@@ -62,13 +62,6 @@
   @import "../common/variables";
 
   .cd-ics-link {
-    summary {
-      cursor: pointer;
-      color: @link-color;
-      &:hover {
-        color: #005e89;
-      }
-    }
     input {
       max-width: 170px;
       border-right-width: 0px;
@@ -86,6 +79,13 @@
       position: relative;
       &--hidden {
         opacity: 1;
+      }
+    }
+    summary {
+      cursor: pointer;
+      color: @link-color;
+      &:hover {
+        color: #005e89;
       }
     }
   }

--- a/src/events/cd-ics-link.vue
+++ b/src/events/cd-ics-link.vue
@@ -59,6 +59,8 @@
   };
 </script>
 <style scoped lang="less">
+  @import "../common/variables";
+
   .cd-ics-link {
     input {
       max-width: 170px;
@@ -77,6 +79,13 @@
       position: relative;
       &--hidden {
         opacity: 1;
+      }
+    }
+    summary {
+      cursor: pointer;
+      color: @link-color;
+      &:hover {
+        color: #005e89;
       }
     }
   }


### PR DESCRIPTION
Calendar subscribe link is now blue.

[Issue-#1256](https://github.com/CoderDojo/community-platform/issues/1256)

Example:
![image](https://user-images.githubusercontent.com/29492869/56304722-5b3d0580-6104-11e9-97c7-7cab1fa735f1.png)
