### PR TITLE
Ensure en_US locale returns projects

### DIFF
--- a/src/dashboard/cd-dashboard-projects.vue
+++ b/src/dashboard/cd-dashboard-projects.vue
@@ -4,7 +4,7 @@
     <h2 class="cd-dashboard-projects__header visible-xs">{{ $t('Here are some projects you can try') }}</h2>
     <hr class ="cd-dashboard-projects__divider visible-xs">
     <div v-show="isDisplayable" class="cd-dashboard-projects__cards">
-      <a class="cd-dashboard-projects__card" v-for="project in projects" :key="project.id" 
+      <a class="cd-dashboard-projects__card" v-for="project in projects" :key="project.id"
         :href="`https://projects.raspberrypi.org/${locale}/projects/${project.attributes.repositoryName}`"
         v-ga-track-exit-nav>
         <img :src="project.attributes.content.heroImage" />
@@ -41,7 +41,11 @@
       userLocale() {
         const langCookie = LocaleService.getUserLocale();
         if (langCookie) {
-          return langCookie.replace(/"/g, '').replace('_', '-');
+          let formattedLocale = langCookie.replace(/"/g, '').replace('_', '-');
+          if (/en-.*/.test(formattedLocale)) {
+            formattedLocale = 'en';
+          }
+          return formattedLocale;
         }
         return 'en';
       },

--- a/src/dashboard/cd-dashboard-projects.vue
+++ b/src/dashboard/cd-dashboard-projects.vue
@@ -52,17 +52,15 @@
     },
     methods: {
       async loadProjects(locale = 'en') {
-        await ProjectsService.list(locale, { order: 'desc' })
-          .then((data) => {
-            const projects = data.body;
-            if (projects) {
-              this.projects = projects.data.slice(0, 3);
-            }
-          })
-          .catch(() => {
-            // If the request fails it is most likely to be the
-            // locale and we will then fall back to the 'en' locale
-          });
+        try {
+          const projects = (await ProjectsService.list(locale, { order: 'desc' })).body;
+          if (projects) {
+            this.projects = projects.data.slice(0, 3);
+          }
+        } catch (err) {
+          // If the request fails it is most likely to be the
+          // locale and we will then fall back to the 'en' locale
+        }
       },
     },
     async created() {

--- a/src/dashboard/cd-dashboard-projects.vue
+++ b/src/dashboard/cd-dashboard-projects.vue
@@ -52,10 +52,17 @@
     },
     methods: {
       async loadProjects(locale = 'en') {
-        const projects = (await ProjectsService.list(locale, { order: 'desc' })).body;
-        if (projects) {
-          this.projects = projects.data.slice(0, 3);
-        }
+        await ProjectsService.list(locale, { order: 'desc' })
+          .then((data) => {
+            const projects = data.body;
+            if (projects) {
+              this.projects = projects.data.slice(0, 3);
+            }
+          })
+          .catch(() => {
+            // If the request fails it is most likely to be the
+            // locale and we will then fall back to the 'en' locale
+          });
       },
     },
     async created() {

--- a/test/unit/specs/dashboard/cd-dashboard-projects.spec.js
+++ b/test/unit/specs/dashboard/cd-dashboard-projects.spec.js
@@ -69,6 +69,17 @@ describe('Dashboard children component', () => {
         expect(MockLocaleService.getUserLocale).to.have.been.calledOnce;
         expect(res).to.equal('fr-FR');
       });
+      it('should return en when cookie locale is en_US', () => {
+        // ARRANGE
+        MockLocaleService.getUserLocale.returns('"en_US"');
+
+        // EXECUTE
+        const res = vm.userLocale;
+
+        // ASSERT
+        expect(MockLocaleService.getUserLocale).to.have.been.calledOnce;
+        expect(res).to.equal('en');
+      });
     });
   });
 


### PR DESCRIPTION
When the users cookie locale is en_US, or presumably any other en_
locale we were sending the entire locale to learning admin to get
projects back.
Learning admin expects the locale to be 'en' for english.

This PR checks the locale after retrieving it from the user's cookies and formats it if needed.

If we send the incorrect locale the projects on the users dashboard don't load:

![Screenshot 2019-06-10 at 13 39 49](https://user-images.githubusercontent.com/6632347/59195965-4c635400-8b85-11e9-8581-a995a3994f53.png)

The locales as defined in projects admin are:
```
two_letter_locales = %i[
  en
]

four_letter_locales = %i[
  ar-SA az-AZ bg-BG bn-BD ca-ES cs-CZ cy-GB da-DK de-DE el-GR es-ES es-LA et-EE fa-IR fi-FI fr-CA
  fr-FR he-IL hi-IN hr-HR hu-HU id-ID it-IT ja-JP ko-KR me-ME ml-IN nl-NL no-NO pl-PL pt-BR pt-PT
  ro-RO ru-RU sk-SK sl-SI sr-SP sv-SE tr-TR uk-UA vi-VN vls-BE zh-CN zh-TW
]
```

So en is the only two letter case.

It turned out that there was already a check on the `created` vue event to get the `en` locale as a default if no projects had been retrieved.
This wasn't working because the failing request wasn't being handled and an error was being thrown.

I've amended the request to the projects site to swallow an error and let the fallback occur.