### PR TITLE
Show PW reset message if query param present

### DIFF
--- a/src/users/cd-login.vue
+++ b/src/users/cd-login.vue
@@ -3,6 +3,13 @@
     <div class="row">
       <h3 class="cd-login__header text-center">{{ $t('Login') }}</h3>
     </div>
+    <div v-show="passwordReset" class="row">
+      <p class="text-center text-success">
+        <strong>
+          {{ $t('Successfully updated password') }}
+        </strong>
+      </p>
+    </div>
     <div class="row">
       <div class="cd-login__box">
         <form @submit.prevent="login">
@@ -53,6 +60,12 @@
         let url = '/register';
         url += this.referer ? `?referer=${this.referer}` : '';
         return url;
+      },
+      passwordReset() {
+        if (this.$route.query.pwr) {
+          return true;
+        }
+        return false;
       },
       ...mapGetters(['isLoggedIn']),
     },


### PR DESCRIPTION
The PW reset page is in the old angular code and it needs to redirect to
the login.
To allow us to display a success message to the user we'll pass it in the query