### PR TITLE
Update vue-trix

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "vue-router": "^2.5.3",
     "vue-router-multiguard": "^1.0.3",
     "vue-static-map": "^2.0.0",
-    "vue-trix": "^0.8.1",
+    "vue-trix": "^1.1.0",
     "vue2-google-maps": "^0.7.9",
     "vuex": "^2.3.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8230,10 +8230,10 @@ trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
 
-trix@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/trix/-/trix-1.1.1.tgz#ca8a3fab4d23d960a17e88441d601cb22a86f5d5"
-  integrity sha512-dNHTcryRK0EmwCyJDOBrG6OznL8HNEVVlecq/xzxLj3M9Eht5DV4yl+eCYX8RKyfrtBcNki+mpKIxESgXaGGZA==
+trix@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/trix/-/trix-1.2.0.tgz#b314101abd1d8d3d5da22ae5b866a719a73a6e21"
+  integrity sha512-gJ7edoWzcnc9DBjsgeGkmotVpyVhFQTlSOmUYjwFn71NlGixAhNgsu8pVIq/jkIkbk6om0PSetc9cRJm+qU3+A==
 
 tryit@^1.0.1:
   version "1.0.3"
@@ -8692,12 +8692,12 @@ vue-template-es2015-compiler@^1.2.2:
   version "1.5.3"
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.5.3.tgz#22787de4e37ebd9339b74223bc467d1adee30545"
 
-vue-trix@^0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/vue-trix/-/vue-trix-0.8.1.tgz#196ecc69df380233fc48854985d8490b21cab61b"
-  integrity sha512-fkDW6qwCDz8/56X5glzZ1iaxTLrZSiKbxEKANMUAC+Y2xAzIWlIzZ8FE6nTm0atNt+X6EzCBc48JYFE8aqOb3Q==
+vue-trix@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/vue-trix/-/vue-trix-1.1.0.tgz#62468fcc8dce7269fd5662b95588b8bd6bd06bc2"
+  integrity sha512-W6HL1IhlfZ1fTuE64GNTr9rutYKKETmF8VXHHP2MRCNsFShnA1Tsbu/aqpon0flOf8PmzSXvPm6uJIiMAVDdOQ==
   dependencies:
-    trix "^1.1.0"
+    trix "^1.1.1"
 
 vue-unit-helper@^1.0.9:
   version "1.0.9"


### PR DESCRIPTION
Updating vue-trix fixes an issue with its two-way binding that was causing the cursor to jump to the end of the input field when editing.

See https://github.com/CoderDojo/community-platform/issues/1271
