### PR TITLE
Remove 'No events' header from dojo page

### DIFF
--- a/src/events/cd-event-list.vue
+++ b/src/events/cd-event-list.vue
@@ -5,9 +5,6 @@
     </div>
     <div v-if="!hasFutureEvents" class="cd-event-list__event">
       <div class="cd-event-list__no-events">
-        <div class="cd-event-list__no-events-header" v-if="!hasPastEvents">
-          {{ $t('No Listed Events') }}
-        </div>
         <div v-if="!hasFutureEvents && !hasPastEvents">
           <p class="cd-event-list__no-events-content" v-html="$t('This Dojo may list their events on another website or they may encourage people to attend without booking.')"></p>
           <p class="cd-event-list__no-events-content" v-if="!isDojoMember" v-html="$t(`${dojo.private ? 'Please email the Dojo on {email} to find out about their upcoming events.' : 'Please join this Dojo for updates and email the Dojo on {email} to find out about their upcoming events.' }`, { email: '<a href=\'mailto:' + dojo.email + '\'>' + dojo.email + '</a>' })"></p>


### PR DESCRIPTION
Ref: https://github.com/CoderDojo/community-platform/issues/1279
Tests are the part of the one linked earlier this week,  particularly https://github.com/CoderDojo/cp-zen-frontend/pull/266/files#diff-933cb8e63c3fc7f29ac54ddac4433676R41