### PR TITLE
Handle issues with city data causing errors

### DIFF
--- a/src/events/cd-event-form.vue
+++ b/src/events/cd-event-form.vue
@@ -21,8 +21,10 @@
               <i class="fa fa-pencil pointer" @click="customAddressFormIsVisible = true" v-show="!customAddressFormIsVisible"></i>
               <i class="fa fa-times pointer" @click="customAddressFormIsVisible = false" v-show="customAddressFormIsVisible"></i>
               <div v-if="customAddressFormIsVisible">
-                <input type="text" name="city" v-model="eventCity" class="form-control">
-                <textarea name="address" v-model="eventAddress" rows="3" class="form-control"></textarea>
+                <label for="city">City</label>
+                <input id="city" type="text" name="city" v-model="eventCity" class="form-control">
+                <label for="address">Address</label>
+                <textarea id="address" name="address" v-model="eventAddress" rows="3" class="form-control"></textarea>
               </div>
             </div>
 
@@ -170,7 +172,7 @@
     methods: {
       async initializeStore() {
         if (this.latestEvent) {
-          EventStore.commit('setCityFromObject', this.latestEvent.city);
+          EventStore.commit('setCityFromEventObject', this.latestEvent.city);
           EventStore.commit('setAddress', this.latestEvent.address);
           EventStore.commit('setDescription', this.latestEvent.description);
           EventStore.commit('generateNextEventDates',
@@ -181,7 +183,7 @@
         } else {
           EventStore.commit('setDescription', this.dojo.notes);
           EventStore.commit('setAddress', this.dojo.address1);
-          EventStore.commit('setCity', this.dojo.city.name);
+          EventStore.commit('setCity', this.dojo);
         }
         EventStore.commit('setCountry', this.dojo.country);
         EventStore.commit('setDojoId', this.dojo.id);
@@ -236,10 +238,10 @@
       },
       eventCity: {
         get() {
-          return EventStore.getters.city;
+          return EventStore.getters.city || '';
         },
         set(value) {
-          EventStore.commit('setCity', value);
+          EventStore.commit('setCity', { city: { nameWithHierarchy: value } });
         },
       },
       eventDescription: {

--- a/src/events/event-store.js
+++ b/src/events/event-store.js
@@ -73,6 +73,10 @@ const store = new Vuex.Store({
       delete event.startTime;
       delete event.endTime;
 
+      if (event.city == null) {
+        event.city = {};
+      }
+
       // This is a workaround for '$$hashKey': 'value' in the json objects of some events.
       // This is something from angular tracking its props being persisted somehow.
       if (event.city.nameWithHierarchy) {

--- a/src/events/event-store.js
+++ b/src/events/event-store.js
@@ -75,10 +75,8 @@ const store = new Vuex.Store({
 
       // This is a workaround for '$$hashKey': 'value' in the json objects of some events.
       // This is something from angular tracking its props being persisted somehow.
-      let city = {};
       if (event.city.nameWithHierarchy) {
-        city = { nameWithHierarchy: event.city.nameWithHierarchy };
-        delete event.city;
+        event.city = { nameWithHierarchy: event.city.nameWithHierarchy };
       }
 
       if (event.sessions) {
@@ -86,7 +84,7 @@ const store = new Vuex.Store({
       }
 
       // default is to not send emails when editing
-      state.event = { ...event, city, sendEmails: false };
+      state.event = { ...event, sendEmails: false };
     },
 
     setEventName(state, name) {

--- a/src/events/event-store.js
+++ b/src/events/event-store.js
@@ -5,8 +5,16 @@ const store = new Vuex.Store({
   strict: true,
   state: {
     eventDate: moment().format('YYYY-MM-DD'),
-    startTime: moment.utc().add(2, 'hours').minute(0).format('HH:mm'),
-    endTime: moment.utc().add(3, 'hours').minute(0).format('HH:mm'),
+    startTime: moment
+      .utc()
+      .add(2, 'hours')
+      .minute(0)
+      .format('HH:mm'),
+    endTime: moment
+      .utc()
+      .add(3, 'hours')
+      .minute(0)
+      .format('HH:mm'),
     event: {
       name: '',
       description: '',
@@ -24,9 +32,18 @@ const store = new Vuex.Store({
       notifyOnApplicant: false,
       sendEmails: true,
       newForm: true,
-      dates: [{
-        startTime: moment.utc().add(2, 'hours').minute(0),
-        endTime: moment.utc().add(3, 'hours').minute(0) }],
+      dates: [
+        {
+          startTime: moment
+            .utc()
+            .add(2, 'hours')
+            .minute(0),
+          endTime: moment
+            .utc()
+            .add(3, 'hours')
+            .minute(0),
+        },
+      ],
       sessions: [
         {
           name: 'Dojo',
@@ -55,19 +72,28 @@ const store = new Vuex.Store({
       delete event.position;
       delete event.startTime;
       delete event.endTime;
+
+      // This is a workaround for '$$hashKey': 'value' in the json objects of some events.
+      // This is something from angular tracking its props being persisted somehow.
+      let city = {};
+      if (event.city.nameWithHierarchy) {
+        city = { nameWithHierarchy: event.city.nameWithHierarchy };
+        delete event.city;
+      }
+
       if (event.sessions) {
         event.sessions[0].tickets.forEach(t => delete t.approvedApplications);
       }
 
       // default is to not send emails when editing
-      state.event = { ...event, sendEmails: false };
+      state.event = { ...event, city, sendEmails: false };
     },
 
     setEventName(state, name) {
       state.event.name = name;
     },
 
-    setCityFromObject(state, cityObject) {
+    setCityFromEventObject(state, cityObject) {
       if (cityObject) {
         state.event.city = {
           nameWithHierarchy: cityObject.nameWithHierarchy || cityObject.toponymName,
@@ -83,8 +109,12 @@ const store = new Vuex.Store({
       state.event.description = description;
     },
 
-    setCity(state, value) {
-      state.event.city = { nameWithHierarchy: value };
+    setCity(state, dojo) {
+      if (dojo.city === null || dojo.city.nameWithHierarchy === undefined) {
+        state.event.city = {};
+        return;
+      }
+      state.event.city = { nameWithHierarchy: dojo.city.nameWithHierarchy };
     },
 
     setCountry(state, value) {
@@ -101,9 +131,12 @@ const store = new Vuex.Store({
       const inPast = moment().diff(newDate, 'days') > 0;
       if (inPast) {
         const neededDay = startDate.day();
-        newDate = (moment().isoWeekday() <= neededDay) ?
-          moment().isoWeekday(neededDay) :
-          moment().add(1, 'weeks').isoWeekday(neededDay);
+        newDate =
+          moment().isoWeekday() <= neededDay
+            ? moment().isoWeekday(neededDay)
+            : moment()
+                .add(1, 'weeks')
+                .isoWeekday(neededDay);
       }
 
       state.eventDate = newDate.format('YYYY-MM-DD');
@@ -129,17 +162,23 @@ const store = new Vuex.Store({
         // Any event that has more than one session was created using the old form
         // and it is unlikely to map to the new form structure
         const previousTickets = event.sessions[0].tickets;
-        const prevYouthTickets = previousTickets.find(ticket => ticket.name === 'Youth');
-        const prevMentorTickets = previousTickets.find(ticket => ticket.name === 'Mentor');
+        const prevYouthTickets = previousTickets.find(
+          ticket => ticket.name === 'Youth',
+        );
+        const prevMentorTickets = previousTickets.find(
+          ticket => ticket.name === 'Mentor',
+        );
 
         if (prevYouthTickets !== undefined) {
-          const youthTickets = state.event.sessions[0].tickets
- .find(ticket => ticket.type === 'ninja');
+          const youthTickets = state.event.sessions[0].tickets.find(
+            ticket => ticket.type === 'ninja',
+          );
           youthTickets.quantity = prevYouthTickets.quantity;
         }
         if (prevMentorTickets !== undefined) {
-          const mentorTickets = state.event.sessions[0]
- .tickets.find(ticket => ticket.type === 'mentor');
+          const mentorTickets = state.event.sessions[0].tickets.find(
+            ticket => ticket.type === 'mentor',
+          );
           mentorTickets.quantity = prevMentorTickets.quantity;
         }
       }
@@ -147,22 +186,32 @@ const store = new Vuex.Store({
 
     updateEventDate(state, value) {
       state.eventDate = value;
-      state.event.dates[0].startTime = moment.utc(`${state.eventDate} ${state.startTime}`);
-      state.event.dates[0].endTime = moment.utc(`${state.eventDate} ${state.endTime}`);
+      state.event.dates[0].startTime = moment.utc(
+        `${state.eventDate} ${state.startTime}`,
+      );
+      state.event.dates[0].endTime = moment.utc(
+        `${state.eventDate} ${state.endTime}`,
+      );
     },
 
     updateStartTime(state, value) {
       state.startTime = value;
-      state.event.dates[0].startTime = moment.utc(`${state.eventDate} ${state.startTime}`);
+      state.event.dates[0].startTime = moment.utc(
+        `${state.eventDate} ${state.startTime}`,
+      );
     },
 
     updateEndTime(state, value) {
       state.endTime = value;
-      state.event.dates[0].endTime = moment.utc(`${state.eventDate} ${state.endTime}`);
+      state.event.dates[0].endTime = moment.utc(
+        `${state.eventDate} ${state.endTime}`,
+      );
     },
 
     updateTicketQuantity(state, { type, quantity }) {
-      const tickets = state.event.sessions[0].tickets.find(ticket => ticket.type === type);
+      const tickets = state.event.sessions[0].tickets.find(
+        ticket => ticket.type === type,
+      );
       tickets.quantity = quantity;
     },
 
@@ -186,7 +235,9 @@ const store = new Vuex.Store({
     sendEmails: state => state.event.sendEmails,
     // eslint-disable-next-line no-unused-vars
     ticketQuantity: state => (type) => {
-      const tickets = state.event.sessions[0].tickets.find(ticket => ticket.type === type);
+      const tickets = state.event.sessions[0].tickets.find(
+        ticket => ticket.type === type,
+      );
       return tickets.quantity;
     },
   },

--- a/test/unit/specs/events/cd-event-form.spec.js
+++ b/test/unit/specs/events/cd-event-form.spec.js
@@ -244,13 +244,15 @@ describe('Event Form component', () => {
         it('sets event values in store from dojo', async () => {
           const vm = vueUnitHelper(EventFormWithMocks);
           vm.loggedInUser = { id: 'U1' };
-          vm.dojo = {
+          const dojoObject = {
             id: 'd1',
             notes: 'The dojo description notes',
             address1: 'Address 1 from Dojo',
             city: { name: 'Dojo City name' },
             country: { alpha2: 'GB' },
           };
+
+          vm.dojo = dojoObject;
 
           await vm.initializeStore();
           expect(MockEventStore.commit).to.have.callCount(6);
@@ -259,7 +261,7 @@ describe('Event Form component', () => {
           expect(MockEventStore.commit).to.have.been
             .calledWith('setAddress', 'Address 1 from Dojo');
           expect(MockEventStore.commit).to.have.been
-            .calledWith('setCity', 'Dojo City name');
+            .calledWith('setCity', dojoObject);
         });
       });
       context('when latestEvent is present', () => {
@@ -281,7 +283,7 @@ describe('Event Form component', () => {
           await vm.initializeStore();
           expect(MockEventStore.commit).to.have.callCount(8);
           expect(MockEventStore.commit).to.have.been
-            .calledWith('setCityFromObject', { nameWithHierarchy: 'City' });
+            .calledWith('setCityFromEventObject', { nameWithHierarchy: 'City' });
           expect(MockEventStore.commit).to.have.been
             .calledWith('setAddress', 'Address from event');
           expect(MockEventStore.commit).to.have.been

--- a/test/unit/specs/events/event-store.spec.js
+++ b/test/unit/specs/events/event-store.spec.js
@@ -53,12 +53,26 @@ describe('Event Store', () => {
   describe('mutations', () => {
     describe('mutations.setEvent', () => {
       it('sets event values correctly with default sendEmails', () => {
-        const event = { id: 1, name: 'Event name' };
+        const event = { id: 1, name: 'Event name', city: {} };
         EventStore.commit('setEvent', event);
 
         expect(EventStore.state.event).to.deep.equal({
           id: 1,
           name: 'Event name',
+          sendEmails: false,
+          city: {},
+        });
+      });
+
+
+      it('removes $$hashKey entries in city', () => {
+        const event = { id: 1, name: 'Event name', city: { nameWithHierarchy: 'Newcastle upon Tyne', $$hashKey: 'object:1301' } };
+        EventStore.commit('setEvent', event);
+
+        expect(EventStore.state.event).to.deep.equal({
+          id: 1,
+          name: 'Event name',
+          city: { nameWithHierarchy: 'Newcastle upon Tyne' },
           sendEmails: false,
         });
       });
@@ -71,16 +85,16 @@ describe('Event Store', () => {
       });
     });
 
-    describe('mutations.setCityFromObject', () => {
+    describe('mutations.setCityFromEventObject', () => {
       context('when city object has nameWithHierarcy', () => {
         it('sets city correctly', () => {
-          EventStore.commit('setCityFromObject', { nameWithHierarchy: 'Sheffield' });
+          EventStore.commit('setCityFromEventObject', { nameWithHierarchy: 'Sheffield' });
           expect(EventStore.state.event.city).to.eql({ nameWithHierarchy: 'Sheffield' });
         });
       });
       context('when city object has toponymName', () => {
         it('sets city correctly', () => {
-          EventStore.commit('setCityFromObject', { toponymName: 'Sheffield' });
+          EventStore.commit('setCityFromEventObject', { toponymName: 'Sheffield' });
           expect(EventStore.state.event.city).to.eql({ nameWithHierarchy: 'Sheffield' });
         });
       });
@@ -102,8 +116,18 @@ describe('Event Store', () => {
 
     describe('mutations.setCity', () => {
       it('sets city correctly', () => {
-        EventStore.commit('setCity', 'Sheffield');
+        EventStore.commit('setCity', { city: { nameWithHierarchy: 'Sheffield' } });
         expect(EventStore.state.event.city).to.eql({ nameWithHierarchy: 'Sheffield' });
+      });
+
+      it('handles dojo city being null', () => {
+        EventStore.commit('setCity', { city: null });
+        expect(EventStore.state.event.city).to.eql({});
+      });
+
+      it('handles dojo city being empty', () => {
+        EventStore.commit('setCity', { city: {} });
+        expect(EventStore.state.event.city).to.eql({});
       });
     });
 

--- a/test/unit/specs/events/event-store.spec.js
+++ b/test/unit/specs/events/event-store.spec.js
@@ -76,6 +76,18 @@ describe('Event Store', () => {
           sendEmails: false,
         });
       });
+
+      it('handles city being null', () => {
+        const event = { id: 1, name: 'Event name', city: null };
+        EventStore.commit('setEvent', event);
+
+        expect(EventStore.state.event).to.deep.equal({
+          id: 1,
+          name: 'Event name',
+          city: {},
+          sendEmails: false,
+        });
+      });
     });
 
     describe('mutations.setEventName', () => {


### PR DESCRIPTION
Some events ended up with data like:
`{"nameWithHierarchy":"City Name","$$hashKey":"object:1234"}`
in the city field. The hashKey prop appears to be coming from angular.

This was breaking editing the events as the prop key was not allowed but
was submitted with the form.

We now pull out the `nameWithHierarchy` prop if it is there and strip
the rest.

We also handle the case where the dojo city value is null or empty when
creating your first event.