### PR TITLE
RPI auth opt in/out page

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,6 +122,16 @@ exports.register = function (server, options, next) {
 
   server.route({
     method: 'GET',
+    path: '/raspberry-opt',
+    handler: {
+      file: {
+        path: 'index.html'
+      }
+    }
+  });
+
+  server.route({
+    method: 'GET',
     path: '/login',
     handler: {
       file: {

--- a/src/common/cd-header.vue
+++ b/src/common/cd-header.vue
@@ -9,8 +9,8 @@
         <div class="cd-menu__nav-right">
             <a class="emphasis" href="https://help.coderdojo.com">{{ $t('Help') }}</a>
           <div class="cd-menu__account">
-            <a href="/register/user">{{ $t('Register') }}</a>
-            <a href="/login">{{ $t('Login') }}</a>
+            <a :href="registerPath">{{ $t('Register') }}</a>
+            <a :href="loginPath">{{ $t('Login') }}</a>
          </div>
          <div class="cd-menu__profile">
             <div class="cd-menu__profile-pic"></div>
@@ -25,7 +25,7 @@
               <li class="cd-menu__cdf-admin-link"><a href="/dashboard/manage-dojos">{{ $t('Manage Dojos') }}</a></li>
               <li class="cd-menu__cdf-admin-link"><a href="http://badgekit.coderdojo.com/">Badgekit</a></li>
               <li class="cd-menu__cdf-admin-link"><a href="/dashboard/stats">{{ $t('Stats') }}</a></li>
-              <li><a class="cd-menu__referer-link" href="/logout">{{ $t('Logout') }}</a></li>
+              <li><a class="cd-menu__referer-link" :href="logoutPath">{{ $t('Logout') }}</a></li>
             </ul>
           </div>
         </div>
@@ -63,8 +63,8 @@
         <div class="cd-menu__content-pre">
           <a class="emphasis" href="https://help.coderdojo.com">{{ $t('Help') }}</a>
           <div class="cd-menu__account">
-            <a href="/register/user">{{ $t('Register') }}</a>
-            <a href="/login">{{ $t('Login') }}</a>
+            <a :href="registerPath">{{ $t('Register') }}</a>
+            <a :href="loginPath">{{ $t('Login') }}</a>
           </div>
           <ul class="cd-menu__content-block">
             <li class="cd-menu__profile">
@@ -92,7 +92,7 @@
                     <li class="cd-menu__cdf-admin-link"><a href="/dashboard/manage-dojos">{{ $t('Manage Dojos') }}</a></li>
                     <li class="cd-menu__cdf-admin-link"><a href="http://badgekit.coderdojo.com/">Badgekit</a></li>
                     <li class="cd-menu__cdf-admin-link"><a href="/dashboard/stats">{{ $t('Stats') }}</a></li>
-                    <li><a class="cd-menu__referer-link" href="/logout">{{ $t('Logout') }}</a></li>
+                    <li><a class="cd-menu__referer-link" :href="logoutPath">{{ $t('Logout') }}</a></li>
                   </ul>
                 </div>
               </div>
@@ -133,7 +133,11 @@ import '@coderdojo/cd-common/dist/cd-common.min';
 export default {
   name: 'cd-header',
   data() {
+    const rpiAuthFlag = window.localStorage.getItem('rpiAuth') === 'true';
     return {
+      loginPath: rpiAuthFlag ? '/rpi/login' : '/login',
+      logoutPath: rpiAuthFlag ? '/rpi/logout' : '/logout',
+      registerPath: rpiAuthFlag ? '/rpi/register' : '/register/user',
       navigationLinks: [
         {
           href: 'https://coderdojo.com/about/',

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -11,6 +11,7 @@ import EventForm from '@/events/cd-event-form';
 import BookingConfirmation from '@/events/order/cd-booking-confirmation';
 import Login from '@/users/cd-login';
 import AccountType from '@/users/cd-account-type';
+import RaspberryOpt from '@/users/cd-raspberry-opt';
 import orderWrapper from '@/events/order/wrapper';
 import UserService from '@/users/service';
 import store from '@/store';
@@ -112,6 +113,11 @@ const router = new Router({
           path: '/account-type',
           name: 'AccountType',
           component: AccountType,
+        },
+        {
+          path: '/raspberry-opt',
+          name: 'RaspberryOpt',
+          component: RaspberryOpt,
         },
         {
           path: '/login',

--- a/src/users/cd-login.vue
+++ b/src/users/cd-login.vue
@@ -107,9 +107,6 @@
             this.errors.clear();
           }
           if (response.body.ok === false) {
-            if (response.body.why === 'raspberry-linked') {
-              window.localStorage.setItem('rpiAuth', true);
-            }
             this.errors.add({
               field: 'loginFailed',
               msg: response.body.why });

--- a/src/users/cd-login.vue
+++ b/src/users/cd-login.vue
@@ -36,6 +36,9 @@
             {{ $t('The account for email {msg} is linked to a My Raspberry Pi account.', { msg: email }) }}
           </p>
           <p>
+            <a :href="`/raspberry-opt?optIn=true`">{{$t('Opt this browser in to My Raspberry Pi authentication.')}}</a>
+          </p>
+          <p>
             <a :href="`/rpi/login?user=${email}`">{{$t('Login through My Raspberry Pi.')}}</a>
           </p>
           <p>
@@ -104,10 +107,14 @@
             this.errors.clear();
           }
           if (response.body.ok === false) {
+            if (response.body.why === 'raspberry-linked') {
+              window.localStorage.setItem('rpiAuth', true);
+            }
             this.errors.add({
               field: 'loginFailed',
               msg: response.body.why });
           } else {
+            window.localStorage.clear('rpiAuth');
             const forumUrl = `^${Vue.config.forumsUrlBase}/auth/CoderDojo$`;
             if (this.redirectUrl.match(forumUrl)) {
               this.redirectTo(this.redirectUrl);

--- a/src/users/cd-raspberry-opt.vue
+++ b/src/users/cd-raspberry-opt.vue
@@ -1,0 +1,80 @@
+<template>
+  <div class="cd-auth-type container-fluid">
+    <div class="row">
+      <div class="cd-auth-type__box">
+        <span v-if="rpiAuthFlag">
+          <h3
+            class="cd-auth-type__header"
+          >{{ $t("This browser is opted in to My Raspberry Pi authentication.") }}</h3>
+          <div class="form-group text-center">
+            <button class="cd-auth-type__opt btn btn-primary" v-on:click="optOut">Opt Out</button>
+          <div>
+        </span>
+        <span v-else>
+          <h3
+            class="cd-auth-type__header"
+          >{{ $t("This browser is opted out of My Raspberry Pi authentication.") }}</h3>
+          <div class="form-group text-center">
+            <button class="cd-auth-type__opt btn btn-primary" v-on:click="optIn">Opt In</button>
+          <div>
+        </span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import store from '@/store';
+
+export default {
+  name: 'Auth-Type',
+  created() {
+    if (this.$route.query.optIn) {
+      const rpiAuthFlag = window.localStorage.getItem('rpiAuth') === 'true';
+      if (!rpiAuthFlag) {
+        this.optIn();
+      }
+    }
+  },
+  data() {
+    return {
+      rpiAuthFlag: window.localStorage.getItem('rpiAuth') === 'true',
+    };
+  },
+  store,
+  methods: {
+    optIn() {
+      window.localStorage.setItem('rpiAuth', true);
+      location.reload();
+    },
+    optOut() {
+      window.localStorage.clear('rpiAuth');
+      // reload and clear optIn query param
+      location.href = location.href.split('?')[0];
+    },
+  },
+};
+</script>
+
+<style scoped lang="less">
+@import "~@coderdojo/cd-common/common/_colors";
+@import "../common/styles/cd-primary-button.less";
+
+.cd-auth-type {
+  &__header {
+    padding: 12px;
+  }
+  &__box {
+    border-style: solid;
+    border-color: @cd-orange;
+    border-width: 1px 1px 3px 1px;
+    padding: 32px 56px 56px;
+    max-width: 425px;
+    margin: 20px auto 128px;
+  }
+
+  &__opt {
+    .primary-button;
+  }
+}
+</style>


### PR DESCRIPTION
Issue: https://github.com/RaspberryPiFoundation/profile/issues/1060

- Dynamic header auth links baed on `rpiAuth` local storage flag
- New page at `/raspberry-opt` for seeing current state & opting in/out of raspberry pi authentication for the browser

Sets local storage flag `rpiAuth` to `true` to opt in
Clears local storage flag `rpiAuth` to opt out

If queryParam `optIn` is present (e.g `/raspberry-opt?optIn=true`) browser is forced to opt in on load.

![Screen Shot 2020-04-22 at 08 45 59](https://user-images.githubusercontent.com/2471488/79955109-36e1da80-8476-11ea-826c-0331ed8eafd7.png)

![Screen Shot 2020-04-22 at 08 50 00](https://user-images.githubusercontent.com/2471488/79955176-4f51f500-8476-11ea-902c-65cbba46dba0.png)
