### PR TITLE
Update link to point to event session

### DIFF
--- a/src/events/cd-event-list-item.vue
+++ b/src/events/cd-event-list-item.vue
@@ -70,7 +70,7 @@
         return this.event.sessions.map(session => session.name).join(', ');
       },
       bookLink() {
-        return { name: 'LoginOrRegister', params: { eventId: this.event.id } };
+        return { name: 'EventSessions', params: { eventId: this.event.id } };
       },
     },
     filters: {
@@ -86,7 +86,7 @@
   .cd-event-list-item {
     .cd-event-tile;
     &--past {
-      border-color: #bdc3c6; 
+      border-color: #bdc3c6;
     }
   }
 </style>


### PR DESCRIPTION
The LoginOrRegister route no longer exists as that is handled by profile
now.

Sending to the session page itself allows the normal auth checks to send
the user to profile if they are not logged in.