### PR TITLE
Send event-details page to session page.

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -125,6 +125,7 @@ const router = new Router({
               path: '',
               component: EventDetails,
               props: true,
+              redirect: { name: 'EventSessions' },
               children: [
                 {
                   path: 'sessions',


### PR DESCRIPTION
Before zen auth was removed the event-details route would check for a
logged in user before sending on to the session page.
The user check is no longer necessary but we still need to redirect to
the session page.