### PR TITLE
POC: Text direction component

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,11 +1,13 @@
 <template>
   <div id="app">
-    <cd-header></cd-header>
-    <div class="cd-menu__content-container">
-      <router-view></router-view>
-      <cd-cookie-notice></cd-cookie-notice>
-    </div>
-    <cd-footer></cd-footer>
+    <cd-text-direction-wrapper>
+      <cd-header></cd-header>
+      <div class="cd-menu__content-container">
+        <router-view></router-view>
+        <cd-cookie-notice></cd-cookie-notice>
+      </div>
+      <cd-footer></cd-footer>
+    </cd-text-direction-wrapper>
   </div>
 </template>
 
@@ -14,11 +16,13 @@
   import cdHeader from './common/cd-header';
   import cdFooter from './common/cd-footer';
   import cdCookieNotice from './common/cd-cookie-notice';
+  import cdTextDirectionWrapper from './common/cd-text-direction-wrapper';
 
   export default {
     name: 'app',
     store,
     components: {
+      cdTextDirectionWrapper,
       cdHeader,
       cdFooter,
       cdCookieNotice,

--- a/src/common/cd-covid-banner.vue
+++ b/src/common/cd-covid-banner.vue
@@ -1,25 +1,34 @@
 <template>
     <div class="cd-banner">
-      <p>
-         {{ $t('Thank you for your interest in joining the CoderDojo community!') }}
-         {{ $t('Due to the coronavirus pandemic, there are different restrictions in place across the world.') }}
-         {{ $t('Please follow the appropriate public health advice for your country or region before planning in-person club events.') }}
-      </p>
-      <p>
-        {{ $t('If you are ready to hold in-person club events soon, please') }}
-        <a class="cd-banner-link" href="https://zen.coderdojo.com/dashboard/start-dojo">{{ $t('register your details') }}</a>
-        {{ $t('and we will be in touch.') }}
-      </p>
-      <p>
-        {{ $t('If you’re not able to start your Dojo in person yet, there are many other ways that you can get involved in the meantime.') }}
-        {{ $t('Check out the exciting opportunities for young people, parents, volunteers, and educators to learn and get creative with tech through') }}
-        <a class="cd-banner-link" target="_blank" href="https://www.raspberrypi.org/learn/?utm_source=coderdojo&amp;utm_medium=covid-banner&amp;utm_campaign=dmah">{{ $t('Digital Making at Home') }}</a>
-        {{ $t('from the Raspberry Pi Foundation.') }}
-      </p>
+      <cd-text-direction-wrapper direction="ltr">
+        <p>
+          {{ $t('Thank you for your interest in joining the CoderDojo community!') }}
+          {{ $t('Due to the coronavirus pandemic, there are different restrictions in place across the world.') }}
+          {{ $t('Please follow the appropriate public health advice for your country or region before planning in-person club events.') }}
+        </p>
+        <p>
+          {{ $t('If you are ready to hold in-person club events soon, please') }}
+          <a class="cd-banner-link" href="https://zen.coderdojo.com/dashboard/start-dojo">{{ $t('register your details') }}</a>
+          {{ $t('and we will be in touch.') }}
+        </p>
+        <p>
+          {{ $t('If you’re not able to start your Dojo in person yet, there are many other ways that you can get involved in the meantime.') }}
+          {{ $t('Check out the exciting opportunities for young people, parents, volunteers, and educators to learn and get creative with tech through') }}
+          <a class="cd-banner-link" target="_blank" href="https://www.raspberrypi.org/learn/?utm_source=coderdojo&amp;utm_medium=covid-banner&amp;utm_campaign=dmah">{{ $t('Digital Making at Home') }}</a>
+          {{ $t('from the Raspberry Pi Foundation.') }}
+        </p>
+      </cd-text-direction-wrapper>
     </div>
 </template>
 
 <script>
+import cdTextDirectionWrapper from './cd-text-direction-wrapper';
+
+export default {
+  components: {
+    cdTextDirectionWrapper,
+  },
+};
 </script>
 
 <style scoped lang="less">

--- a/src/common/cd-text-direction-wrapper.vue
+++ b/src/common/cd-text-direction-wrapper.vue
@@ -1,0 +1,28 @@
+<template>
+  <div class="lang-wrapper" v-bind:dir="textDirection">
+    <slot></slot>
+  </div>
+</template>
+
+<script>
+export default {
+  props: ['direction'],
+  computed: {
+    textDirection() {
+      if (this.direction) {
+        return this.direction;
+      }
+
+      const config = this.$store.getters.chosenLanguageConfig;
+      let direction = 'ltr';
+      if (config && config.dir) {
+        direction = config.dir;
+      }
+      return direction;
+    },
+  },
+};
+</script>
+
+<style>
+</style>

--- a/src/common/cd-text-direction-wrapper.vue
+++ b/src/common/cd-text-direction-wrapper.vue
@@ -6,7 +6,10 @@
 
 <script>
 export default {
-  props: ['direction'],
+  name: 'TextDirectionWrapper',
+  props: {
+    direction: String,
+  },
   computed: {
     textDirection() {
       if (this.direction) {

--- a/src/locale/cd-lang-picker.vue
+++ b/src/locale/cd-lang-picker.vue
@@ -3,7 +3,7 @@
     <div class="col-md-4 col-sm-6">
       <span class="fa fa-language fa-2x cd-lang-picker__icon"></span>
       <select class="cd-lang-picker__select" v-model="lang">
-        <option v-for="availableLanguage in availableLanguages" :value="availableLanguage.code">{{ availableLanguage.name }} ({{ availableLanguage.country }})</option>
+        <option v-for="availableLanguage in availableLanguages" :value="availableLanguage.code" v-bind:key="availableLanguage.code">{{ availableLanguage.name }} ({{ availableLanguage.country }})</option>
       </select>
     </div>
     <div class="col-md-8 col-sm-6">
@@ -52,22 +52,26 @@
             this.setMomentLocale(val);
             this.$i18n.setLocaleMessage(val, strings);
             this.$i18n.locale = val;
+            const matchingLanguageConfig = find(this.availableLanguages,
+              language => language.code === val);
+            this.$store.dispatch('updateChosenLanguageConfig', matchingLanguageConfig);
           });
       },
     },
     async created() {
       this.availableLanguages = (await this.getAvailableLanguages()).body;
       const browserLocale = navigator.language.replace('-', '_');
-      const matchingLocale = find(this.availableLanguages,
+      const matchingLanguageConfig = find(this.availableLanguages,
         language => language.code === browserLocale);
       const langCookie = Cookie.get('NG_TRANSLATE_LANG_KEY');
       if (langCookie) {
         this.lang = langCookie.substring(1, langCookie.length - 1);
-      } else if (matchingLocale) {
+      } else if (matchingLanguageConfig) {
         this.lang = browserLocale;
       } else {
         this.lang = 'en_US';
       }
+      this.$store.dispatch('updateChosenLanguageConfig', matchingLanguageConfig);
     },
   };
 </script>

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -8,6 +8,7 @@ export default new Vuex.Store({
   state: {
     loggedInUser: null,
     dojo: null,
+    chosenLanguageConfig: null,
   },
   mutations: {
     setLoggedInUser(state, user) {
@@ -15,6 +16,9 @@ export default new Vuex.Store({
     },
     setDojo(state, dojo) {
       Vue.set(state, 'dojo', dojo);
+    },
+    setChosenLanguageConfig(state, chosenLanguageConfig) {
+      Vue.set(state, 'chosenLanguageConfig', chosenLanguageConfig);
     },
   },
   actions: {
@@ -27,6 +31,9 @@ export default new Vuex.Store({
       commit('setDojo', null);
       const dojo = (await Vue.http.get(`${Vue.config.apiServer}/api/2.0/dojos/${dojoId}`)).body;
       commit('setDojo', dojo);
+    },
+    updateChosenLanguageConfig({ commit }, chosenLanguageConfig) {
+      commit('setChosenLanguageConfig', chosenLanguageConfig);
     },
   },
   getters: {
@@ -45,6 +52,7 @@ export default new Vuex.Store({
       state.loggedInUser.login !== null &&
       state.loggedInUser.login.id !== undefined,
     dojo: state => state.dojo,
+    chosenLanguageConfig: state => state.chosenLanguageConfig,
     // User properties
     hasRequests: (state, getters) => getters.isLoggedIn &&
       getters.loggedInUser.joinRequests &&

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,6 +1,7 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
 import order from './modules/order';
+import language from './modules/language';
 
 Vue.use(Vuex);
 
@@ -8,7 +9,6 @@ export default new Vuex.Store({
   state: {
     loggedInUser: null,
     dojo: null,
-    chosenLanguageConfig: null,
   },
   mutations: {
     setLoggedInUser(state, user) {
@@ -16,9 +16,6 @@ export default new Vuex.Store({
     },
     setDojo(state, dojo) {
       Vue.set(state, 'dojo', dojo);
-    },
-    setChosenLanguageConfig(state, chosenLanguageConfig) {
-      Vue.set(state, 'chosenLanguageConfig', chosenLanguageConfig);
     },
   },
   actions: {
@@ -31,9 +28,6 @@ export default new Vuex.Store({
       commit('setDojo', null);
       const dojo = (await Vue.http.get(`${Vue.config.apiServer}/api/2.0/dojos/${dojoId}`)).body;
       commit('setDojo', dojo);
-    },
-    updateChosenLanguageConfig({ commit }, chosenLanguageConfig) {
-      commit('setChosenLanguageConfig', chosenLanguageConfig);
     },
   },
   getters: {
@@ -52,7 +46,6 @@ export default new Vuex.Store({
       state.loggedInUser.login !== null &&
       state.loggedInUser.login.id !== undefined,
     dojo: state => state.dojo,
-    chosenLanguageConfig: state => state.chosenLanguageConfig,
     // User properties
     hasRequests: (state, getters) => getters.isLoggedIn &&
       getters.loggedInUser.joinRequests &&
@@ -60,5 +53,6 @@ export default new Vuex.Store({
   },
   modules: {
     order,
+    language,
   },
 });

--- a/src/store/modules/language.js
+++ b/src/store/modules/language.js
@@ -1,9 +1,5 @@
 import Vue from 'vue';
 
-const state = {
-  chosenLanguageConfig: null,
-};
-
 export const mutations = {
   setChosenLanguageConfig(state, chosenLanguageConfig) {
     Vue.set(state, 'chosenLanguageConfig', chosenLanguageConfig);
@@ -14,15 +10,17 @@ export const actions = {
   updateChosenLanguageConfig({ commit }, chosenLanguageConfig) {
     commit('setChosenLanguageConfig', chosenLanguageConfig);
   },
-}
+};
 
 export const getters = {
   chosenLanguageConfig: state => state.chosenLanguageConfig,
-}
+};
 
 export default {
   namespaced: false,
-  state,
+  state: {
+    chosenLanguageConfig: null,
+  },
   mutations,
   actions,
   getters,

--- a/src/store/modules/language.js
+++ b/src/store/modules/language.js
@@ -1,0 +1,29 @@
+import Vue from 'vue';
+
+const state = {
+  chosenLanguageConfig: null,
+};
+
+export const mutations = {
+  setChosenLanguageConfig(state, chosenLanguageConfig) {
+    Vue.set(state, 'chosenLanguageConfig', chosenLanguageConfig);
+  },
+};
+
+export const actions = {
+  updateChosenLanguageConfig({ commit }, chosenLanguageConfig) {
+    commit('setChosenLanguageConfig', chosenLanguageConfig);
+  },
+}
+
+export const getters = {
+  chosenLanguageConfig: state => state.chosenLanguageConfig,
+}
+
+export default {
+  namespaced: false,
+  state,
+  mutations,
+  actions,
+  getters,
+};

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -1,6 +1,10 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
 import VueResource from 'vue-resource';
+import chai from 'chai';
+import sinonChai from 'sinon-chai';
+
+chai.use(sinonChai);
 
 /* eslint-disable no-extend-native, no-param-reassign, func-names */
 if (!String.prototype.endsWith) {

--- a/test/unit/specs/common/cd-text-direction-wrapper.spec.js
+++ b/test/unit/specs/common/cd-text-direction-wrapper.spec.js
@@ -1,0 +1,45 @@
+import vueUnitHelper from 'vue-unit-helper';
+import TextDirectionWrapper from '@/common/cd-text-direction-wrapper';
+
+describe.only('Text Direction Wrapper', () => {
+
+  describe('computed.textDirection', () => {
+    context('when chosen language specifies a direction', () => {
+      it('returns that value', () => {
+        const vm = vueUnitHelper(TextDirectionWrapper);
+        vm.$store = {
+          getters: {
+            get chosenLanguageConfig() { return { dir: 'test' }},
+          },
+        };
+        expect(vm.textDirection).to.eql('test');
+      });
+    });
+
+    context('when chosen language doesn\'t specify a direction', () => {
+      it('returns default', () => {
+        const vm = vueUnitHelper(TextDirectionWrapper);
+        vm.$store = {
+          getters: {
+            get chosenLanguageConfig() { return { }},
+          },
+        };
+        expect(vm.textDirection).to.eql('ltr');
+      });
+    });
+
+    context('when initialised with a prop', () => {
+      it('overrides the chosen language direction', () => {
+        const vm = vueUnitHelper(TextDirectionWrapper);
+        vm.direction = 'down'
+        vm.$store = {
+          getters: {
+            get chosenLanguageConfig() { return { dir: 'test' }},
+          },
+        };
+        expect(vm.textDirection).to.eql('down');
+      });
+    });
+  });
+
+});

--- a/test/unit/specs/common/cd-text-direction-wrapper.spec.js
+++ b/test/unit/specs/common/cd-text-direction-wrapper.spec.js
@@ -2,14 +2,13 @@ import vueUnitHelper from 'vue-unit-helper';
 import TextDirectionWrapper from '@/common/cd-text-direction-wrapper';
 
 describe('Text Direction Wrapper', () => {
-
   describe('computed.textDirection', () => {
     context('when chosen language specifies a direction', () => {
       it('returns that value', () => {
         const vm = vueUnitHelper(TextDirectionWrapper);
         vm.$store = {
           getters: {
-            get chosenLanguageConfig() { return { dir: 'test' }},
+            get chosenLanguageConfig() { return { dir: 'test' }; },
           },
         };
         expect(vm.textDirection).to.eql('test');
@@ -21,7 +20,7 @@ describe('Text Direction Wrapper', () => {
         const vm = vueUnitHelper(TextDirectionWrapper);
         vm.$store = {
           getters: {
-            get chosenLanguageConfig() { return { }},
+            get chosenLanguageConfig() { return { }; },
           },
         };
         expect(vm.textDirection).to.eql('ltr');
@@ -31,10 +30,10 @@ describe('Text Direction Wrapper', () => {
     context('when initialised with a prop', () => {
       it('overrides the chosen language direction', () => {
         const vm = vueUnitHelper(TextDirectionWrapper);
-        vm.direction = 'down'
+        vm.direction = 'down';
         vm.$store = {
           getters: {
-            get chosenLanguageConfig() { return { dir: 'test' }},
+            get chosenLanguageConfig() { return { dir: 'test' }; },
           },
         };
         expect(vm.textDirection).to.eql('down');

--- a/test/unit/specs/common/cd-text-direction-wrapper.spec.js
+++ b/test/unit/specs/common/cd-text-direction-wrapper.spec.js
@@ -1,7 +1,7 @@
 import vueUnitHelper from 'vue-unit-helper';
 import TextDirectionWrapper from '@/common/cd-text-direction-wrapper';
 
-describe.only('Text Direction Wrapper', () => {
+describe('Text Direction Wrapper', () => {
 
   describe('computed.textDirection', () => {
     context('when chosen language specifies a direction', () => {
@@ -41,5 +41,4 @@ describe.only('Text Direction Wrapper', () => {
       });
     });
   });
-
 });

--- a/test/unit/specs/locale/cd-lang-picker.spec.js
+++ b/test/unit/specs/locale/cd-lang-picker.spec.js
@@ -1,13 +1,14 @@
 import vueUnitHelper from 'vue-unit-helper';
 import LangPicker from '!!vue-loader?inject!@/locale/cd-lang-picker';
 import { expect } from 'chai';
+import Vuex from 'vuex';
 
 describe('Lang Picker', () => {
   let CookieMock;
   let LocaleServiceMock;
   let MomentMock;
   let LangPickerWithMocks;
-  let StoreMock;
+  const StoreMock = new Vuex.Store()
 
   beforeEach(() => {
     CookieMock = {
@@ -26,9 +27,7 @@ describe('Lang Picker', () => {
       moment: MomentMock,
     });
 
-    StoreMock = {
-      dispatch: sinon.stub(),
-    };
+    StoreMock.dispatch = sinon.stub();
   });
 
   afterEach(() => {
@@ -96,7 +95,7 @@ describe('Lang Picker', () => {
             foo: 'foo',
           });
           expect(vm.$i18n.locale).to.equal('es_ES');
-          expect(StoreMock.dispatch.calledOnce).to.eq(true);
+          expect(StoreMock.dispatch).to.have.been.calledWith('updateChosenLanguageConfig');
           done();
         });
       });
@@ -130,7 +129,7 @@ describe('Lang Picker', () => {
 
       // ASSERT
       expect(vm.lang).to.equal('es_ES');
-      expect(StoreMock.dispatch.calledOnce).to.eq(true);
+      expect(StoreMock.dispatch).to.have.been.calledWith('updateChosenLanguageConfig');
     });
 
     it('should set lang to the browser locale if no cookie, and locale matches an available one', async () => {
@@ -146,7 +145,7 @@ describe('Lang Picker', () => {
 
       // ASSERT
       expect(vm.lang).to.equal('it_IT');
-      expect(StoreMock.dispatch.calledOnce).to.eq(true);
+      expect(StoreMock.dispatch).to.have.been.calledWith('updateChosenLanguageConfig');
     });
 
     it('should set lang to en_US if no cookie and browser locale doesnt match available lang', async () => {
@@ -162,7 +161,7 @@ describe('Lang Picker', () => {
 
       // ASSERT
       expect(vm.lang).to.equal('en_US');
-      expect(StoreMock.dispatch.calledOnce).to.eq(true);
+      expect(StoreMock.dispatch).to.have.been.calledWith('updateChosenLanguageConfig');
     });
   });
 });

--- a/test/unit/specs/locale/cd-lang-picker.spec.js
+++ b/test/unit/specs/locale/cd-lang-picker.spec.js
@@ -8,7 +8,7 @@ describe('Lang Picker', () => {
   let LocaleServiceMock;
   let MomentMock;
   let LangPickerWithMocks;
-  const StoreMock = new Vuex.Store()
+  const StoreMock = new Vuex.Store();
 
   beforeEach(() => {
     CookieMock = {

--- a/test/unit/specs/store/modules/language.spec.js
+++ b/test/unit/specs/store/modules/language.spec.js
@@ -1,0 +1,36 @@
+import { mutations, actions, getters } from '@/store/modules/language';
+import { expect } from 'chai';
+
+describe('Language Store', () => {
+  describe('mutations', () => {
+    const { setChosenLanguageConfig } = mutations
+    it('setChosenLanguageConfig', () => {
+      const state = { chosenLanguageConfig: null };
+      const newLanguageConfig = { dir: 'test' };
+
+      setChosenLanguageConfig(state, newLanguageConfig);
+
+      expect(state.chosenLanguageConfig.dir).to.eq('test');
+    });
+  });
+
+  describe('actions', () => {
+    it('updateChosenLanguageConfig', () => {
+      const commit = sinon.spy()
+      const state = {};
+
+      const chosenLanguageConfig = { dir: 'down' };
+
+      actions.updateChosenLanguageConfig({ commit, state }, chosenLanguageConfig);
+
+      expect(commit.args).to.deep.equal([['setChosenLanguageConfig', chosenLanguageConfig]]);
+    });
+  });
+
+  describe('getters', () => {
+    it('chosenLanguageConfig', () => {
+      const state = { chosenLanguageConfig: { dir: 'left' } };
+      expect(getters.chosenLanguageConfig(state).dir).to.eq('left');
+    });
+  });
+});

--- a/test/unit/specs/store/modules/language.spec.js
+++ b/test/unit/specs/store/modules/language.spec.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 
 describe('Language Store', () => {
   describe('mutations', () => {
-    const { setChosenLanguageConfig } = mutations
+    const { setChosenLanguageConfig } = mutations;
     it('setChosenLanguageConfig', () => {
       const state = { chosenLanguageConfig: null };
       const newLanguageConfig = { dir: 'test' };
@@ -16,7 +16,7 @@ describe('Language Store', () => {
 
   describe('actions', () => {
     it('updateChosenLanguageConfig', () => {
-      const commit = sinon.spy()
+      const commit = sinon.spy();
       const state = {};
 
       const chosenLanguageConfig = { dir: 'down' };

--- a/test/unit/specs/store/store.spec.js
+++ b/test/unit/specs/store/store.spec.js
@@ -1,15 +1,16 @@
 import store from '@/store/';
 import { expect } from 'chai';
 
-describe.only('Store', () => {
+describe('Store', () => {
   describe('mutations', () => {
-    it('setChosenLanguageConfig', () => {
-      const newLanguageConfig = { dir: 'test' };
+    // it('setChosenLanguageConfig', () => {
+    //   console.log('store ', store);
+    //   const newLanguageConfig = { dir: 'test' };
 
-      store.commit('setChosenLanguageConfig', newLanguageConfig);
+    //   store.commit('setChosenLanguageConfig', newLanguageConfig);
 
-      expect(store.state.chosenLanguageConfig.dir).to.eq('test');
-    });
+    //   expect(store.state.chosenLanguageConfig.dir).to.eq('test');
+    // });
 
     it('setLoggedInUser', () => {
       const user = { user: 'bob' };
@@ -26,5 +27,13 @@ describe.only('Store', () => {
 
       expect(store.state.dojo.name).to.eq('SuperDojo');
     });
-  })
+  });
+
+  // describe('actions', () => {
+  //   it('updateChosenLanguageConfig', () => {
+  //     console.log('actions: ', store._actions);
+  //     const commit = sinon.spy()
+  //     const state = {};
+  //   });
+  // });
 });

--- a/test/unit/specs/store/store.spec.js
+++ b/test/unit/specs/store/store.spec.js
@@ -1,0 +1,30 @@
+import store from '@/store/';
+import { expect } from 'chai';
+
+describe.only('Store', () => {
+  describe('mutations', () => {
+    it('setChosenLanguageConfig', () => {
+      const newLanguageConfig = { dir: 'test' };
+
+      store.commit('setChosenLanguageConfig', newLanguageConfig);
+
+      expect(store.state.chosenLanguageConfig.dir).to.eq('test');
+    });
+
+    it('setLoggedInUser', () => {
+      const user = { user: 'bob' };
+
+      store.commit('setLoggedInUser', user);
+
+      expect(store.state.loggedInUser.user).to.eq('bob');
+    });
+
+    it('setDojo', () => {
+      const dojo = { name: 'SuperDojo' };
+
+      store.commit('setDojo', dojo);
+
+      expect(store.state.dojo.name).to.eq('SuperDojo');
+    });
+  })
+});

--- a/test/unit/specs/store/store.spec.js
+++ b/test/unit/specs/store/store.spec.js
@@ -3,15 +3,6 @@ import { expect } from 'chai';
 
 describe('Store', () => {
   describe('mutations', () => {
-    // it('setChosenLanguageConfig', () => {
-    //   console.log('store ', store);
-    //   const newLanguageConfig = { dir: 'test' };
-
-    //   store.commit('setChosenLanguageConfig', newLanguageConfig);
-
-    //   expect(store.state.chosenLanguageConfig.dir).to.eq('test');
-    // });
-
     it('setLoggedInUser', () => {
       const user = { user: 'bob' };
 
@@ -28,12 +19,4 @@ describe('Store', () => {
       expect(store.state.dojo.name).to.eq('SuperDojo');
     });
   });
-
-  // describe('actions', () => {
-  //   it('updateChosenLanguageConfig', () => {
-  //     console.log('actions: ', store._actions);
-  //     const commit = sinon.spy()
-  //     const state = {};
-  //   });
-  // });
 });

--- a/test/unit/specs/users/service.spec.js
+++ b/test/unit/specs/users/service.spec.js
@@ -2,16 +2,10 @@ import Vue from 'vue';
 import UserService from 'inject-loader!@/users/service';
 
 describe('UserService', () => {
-  let storeMock;
   let UserServiceWithMocks;
 
   beforeEach(() => {
-    storeMock = {
-      dispatch: sinon.stub(),
-    };
-    UserServiceWithMocks = UserService({
-      '@/store': storeMock,
-    }).default;
+    UserServiceWithMocks = UserService().default;
   });
 
   afterEach(() => {


### PR DESCRIPTION
Add a component that can be used to wrap others and set the text direction.

Text direction can be set as a prop on the component which will override everything else, otherwise, if the config for a chosen language specifies a 'dir' property, this will be used.  Default is 'ltr'

Currently added as a wrapper around the whole app, then a specific wrapper around the Covid banner to set it to LTR as there are no translations for this currently.

May need using in other parts of the site - we will need feedback on where to put it I expect.