### PR TITLE
Point privacy statement to raspberrypi.org/privacy

### DIFF
--- a/src/common/cd-footer.vue
+++ b/src/common/cd-footer.vue
@@ -52,7 +52,7 @@ export default {
           text: 'Charter',
         },
         {
-          href: '/privacy-statement',
+          href: 'https://www.raspberrypi.org/privacy/',
           text: 'Privacy Statement',
         },
         {


### PR DESCRIPTION
Our central privacy policy is now being used across all programs (it includes a cookie policy which lists the specific CoderDojo cookies also).