### PR TITLE
Display online status

### DIFF
--- a/src/dojos/cd-dojo-details.vue
+++ b/src/dojos/cd-dojo-details.vue
@@ -19,6 +19,8 @@
           {{ address }}
           <a class="cd-dojo-details__google-maps-link" target="_blank" rel="noopener noreferrer" v-if="dojoDetails.geoPoint" :href="googleMapsLink">{{ $t('Open in Google Maps') }} <i class="fa fa-chevron-right" aria-hidden="true"></i></a>
         </info-column-section>
+        <info-column-section v-if="dojoDetails.onlineSessions" class="cd-dojo-details__left-column-section" icon="laptop" :header="$t('Running Online')">
+        </info-column-section>
         <info-column-section class="hidden-xs" icon="envelope-o" :header="$t('Email')">
           <a :href="'mailto:' + dojoDetails.email">{{ dojoDetails.email }}</a>
         </info-column-section>

--- a/src/dojos/cd-dojo-list-item.vue
+++ b/src/dojos/cd-dojo-list-item.vue
@@ -13,6 +13,7 @@
       </h4>
       <p class="cd-dojo-list-item__meta">{{dojo.address1}}</p>
       <p class="cd-dojo-list-item__meta">{{buildDojoFrequency(dojo)}}</p>
+      <p v-if="dojo.onlineSessions" class="cd-dojo-list-item__meta"><i class="fa fa-laptop" aria-hidden="true"></i>{{ $t('Running Online') }}</p>
       <event-stamp :dojo="dojo"></event-stamp>
     </div>
   </div>
@@ -66,6 +67,10 @@
     &__meta {
       font-size: 16px;
       margin-bottom: 0;
+    }
+
+    &__meta .fa {
+      margin-right: 8px;
     }
   }
 


### PR DESCRIPTION
If a club has ticked the 'Online' box, show in the club details:

![Screenshot 2020-10-12 at 16 25 26](https://user-images.githubusercontent.com/789846/95766928-e7a19780-0cab-11eb-840d-31004b6e1df8.png)

Also show in the search results:

![Screenshot 2020-10-12 at 16 54 15](https://user-images.githubusercontent.com/789846/95766955-eff9d280-0cab-11eb-80dc-4315f59d1afe.png)
![Screenshot 2020-10-12 at 16 54 30](https://user-images.githubusercontent.com/789846/95766960-f1c39600-0cab-11eb-977a-83103a75f017.png)
