### PR TITLE
Remove the link to the advanced event form

### DIFF
--- a/src/events/cd-event-form.vue
+++ b/src/events/cd-event-form.vue
@@ -128,11 +128,6 @@
               </button>
             </div>
           </form>
-          <div class="flow">
-            <p>We simplified our events experience, read <a href="https://coderdojo.com/?p=17691">about it here</a>.
-            <br/>
-            If you need to customise your event further you can still use the <a :href="`/dashboard/dojo/${dojo.id}/event-form`">advanced events form</a></p>
-          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This simply removes the link from the event form

closes RaspberryPiFoundation/digital-core#111