### PR TITLE
Update google maps API key for test/dev envs.

### DIFF
--- a/config/dev.env.js
+++ b/config/dev.env.js
@@ -6,7 +6,7 @@ module.exports = merge(prodEnv, {
   API_SERVER: '""', // False good idea, remove me
   RECAPTCHA_SITE_KEY: '"6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI"',
   GOOGLE_ANALYTICS_PROPERTY_ID: '"UA-25136319-8"',
-  GOOGLE_MAPS_API_KEY: '"AIzaSyD6WWeWYAVLLO1rmVSLiK-gSQUK8-U6w7w"',
+  GOOGLE_MAPS_API_KEY: '"AIzaSyA4lRJMDmdT_60aUSsih78adO2A9Gzv5UM"',
   NEWS_URL_BASE: '""',
   FORUMS_URL_BASE: '"http://localhost:4567"',
   PROJECTS_URL_BASE: '""',

--- a/config/test.env.js
+++ b/config/test.env.js
@@ -5,6 +5,5 @@ module.exports = merge(devEnv, {
   NODE_ENV: '"testing"',
   API_SERVER: '""', // False good idea, remove me
   GOOGLE_ANALYTICS_PROPERTY_ID: '"UA-25136319-8"',
-  GOOGLE_MAPS_API_KEY: '"AIzaSyD6WWeWYAVLLO1rmVSLiK-gSQUK8-U6w7w"',
   FORUMS_URL_BASE: '"http://localhost:4567"',
 })

--- a/cypress/integration/cookie-notice_spec.js
+++ b/cypress/integration/cookie-notice_spec.js
@@ -18,7 +18,6 @@ describe('Cookie Notice', () => {
     cy.get(basePage.cookieNoticeDismiss).should('be.visible');
     cy.get(findDojoPage.addressSearchInput).type('dublin');
     cy.get(findDojoPage.addressSearchButton).click();
-    cy.get(findDojoPage.dojoLinks).scrollIntoView();
     cy.get(findDojoPage.dojoLinks).eq(0).click();
     cy.get(dojoDetailsPage.name).should('be.visible');
     cy.get(basePage.cookieNoticeDismiss).should('not.be.visible');

--- a/cypress/integration/cookie-notice_spec.js
+++ b/cypress/integration/cookie-notice_spec.js
@@ -18,6 +18,7 @@ describe('Cookie Notice', () => {
     cy.get(basePage.cookieNoticeDismiss).should('be.visible');
     cy.get(findDojoPage.addressSearchInput).type('dublin');
     cy.get(findDojoPage.addressSearchButton).click();
+    cy.get(findDojoPage.dojoLinks).scrollIntoView();
     cy.get(findDojoPage.dojoLinks).eq(0).click();
     cy.get(dojoDetailsPage.name).should('be.visible');
     cy.get(basePage.cookieNoticeDismiss).should('not.be.visible');


### PR DESCRIPTION
Cypress tests were failing, because the cookie banner test couldn't geolocate "dublin".  I found this by running Cypress locally and opening the dev tools inside the chrome session, where there was a warning message about the expired API key.