### PR TITLE
Remove community links

### DIFF
--- a/src/common/cd-header.vue
+++ b/src/common/cd-header.vue
@@ -166,18 +166,6 @@ export default {
           text: 'Community',
           subLinks: [
             {
-              href: '/badges',
-              text: 'Badges',
-            },
-            {
-              href: 'https://forums.coderdojo.com/',
-              text: 'Forums',
-            },
-            {
-              href: 'https://ninjaforums.coderdojo.com/',
-              text: 'Ninja Forums',
-            },
-            {
               href: 'http://coolestprojects.org/',
               text: 'Coolest Projects',
             },


### PR DESCRIPTION
- Related to: https://github.com/RaspberryPiFoundation/digital-foundation/issues/368
- Removes links from the community navbar as specified in the [GSHEET](https://docs.google.com/spreadsheets/d/1BWkOPVbefZo-7Gea9IIkToF7mMS1neVzFOyEFlJ3BjA/edit#gid=1012642429)

**Screenshots**
![Screenshot 2022-09-22 at 15 43 37](https://user-images.githubusercontent.com/14238047/191778177-2297714a-09b3-4ec3-9dbe-c36b6a5bf05e.png)

**Only merge after Blog is live**