### PR TITLE
Update HREF of links 

### DIFF
--- a/src/common/cd-header.vue
+++ b/src/common/cd-header.vue
@@ -143,7 +143,7 @@ export default {
           text: 'About',
         },
         {
-          href: 'https://coderdojo.com/attend-a-dojo/',
+          href: 'https://coderdojo.com/find/',
           text: 'Attend a Dojo',
         },
         {
@@ -155,7 +155,7 @@ export default {
           text: 'Start a Dojo',
         },
         {
-          href: 'https://coderdojo.com/resources/',
+          href: 'https://coderdojo.com/session-resources/',
           text: 'Resources',
         },
         {


### PR DESCRIPTION
- Related to https://github.com/RaspberryPiFoundation/digital-foundation/issues/368
- Update links from [gsheet](https://docs.google.com/spreadsheets/d/1BWkOPVbefZo-7Gea9IIkToF7mMS1neVzFOyEFlJ3BjA/edit#gid=1012642429) 

^^ New blog is same href so doesn't need updating