### PR TITLE
Fix-join-button-loop

### DIFF
--- a/src/events/cd-event-list.vue
+++ b/src/events/cd-event-list.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="cd-event-list" >
+  <div class="cd-event-list">
     <div class="cd-event-list__heading" >
       <h4>{{ $t('Upcoming Events') }}</h4>
     </div>
@@ -36,8 +36,7 @@
   import DojosService from '@/dojos/service';
   import EventListItem from '@/events/cd-event-list-item';
   import service from './service';
-
-
+  
   export default {
     name: 'event-list',
     props: {
@@ -116,7 +115,7 @@
           /* eslint-enable no-alert */
           this.loadUserDojoRole();
         } else {
-          location.href = `/register?referer=${this.$route.path}`;
+          location.href = `/login`;
         }
       },
     },

--- a/src/events/cd-event-list.vue
+++ b/src/events/cd-event-list.vue
@@ -115,7 +115,7 @@
           /* eslint-enable no-alert */
           this.loadUserDojoRole();
         } else {
-          location.href = `/login`;
+          location.href = '/login';
         }
       },
     },

--- a/src/events/cd-event-list.vue
+++ b/src/events/cd-event-list.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="cd-event-list">
+  <div class="cd-event-list" >
     <div class="cd-event-list__heading" >
       <h4>{{ $t('Upcoming Events') }}</h4>
     </div>
@@ -115,7 +115,7 @@
           /* eslint-enable no-alert */
           this.loadUserDojoRole();
         } else {
-          location.href = `/login?referer=${this.$route.path}`;
+          location.href = `/register?referer=${this.$route.path}`;
         }
       },
     },

--- a/src/events/cd-event-list.vue
+++ b/src/events/cd-event-list.vue
@@ -115,7 +115,7 @@
           /* eslint-enable no-alert */
           this.loadUserDojoRole();
         } else {
-          location.href = '/login';
+          location.href = `/login?referer=${this.$route.path}`;
         }
       },
     },


### PR DESCRIPTION
The Join Dojo button on a club page goes in a loop of logging in to raspberry pi (and NOT CoderDojo) that isn't obvious to users, making it hard to join a club.

Change link on button to use login so that the user stays on CD and can at least (eventually) go back and join the club.

**Notes**
- Have just changed the link, have not updated `register` in general. Login and register was changed [here](https://github.com/CoderDojo/cp-zen-frontend/commit/6a127bfa1ed154e0023d34eeb8fa88c0580e870d).
